### PR TITLE
README: fix coffeescript install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ At the time this is written, here is the advantages of this one:
 
 ## Installation
 
-- install **Hubot** and **CoffeeScript**: `npm install -g hubot coffeescript`
+- install **Hubot** and **CoffeeScript**: `npm install -g hubot coffee-script`
 - create your bot and install its dependencies:
 
 ```


### PR DESCRIPTION
Because otherwise you get this:

```
❯ npm -g install coffeescript
npm WARN deprecated coffeescript@99.999.99999: You misspelled 'coffee-script'

> coffeescript@99.999.99999 preinstall /home/fiws/npm/lib/node_modules/coffeescript
> node super-evil-script-omg-for-reals.js

You misspelled 'coffee-script'
npm ERR! Linux 3.18.6-1-ARCH
npm ERR! argv "node" "/home/fiws/npm/bin/npm" "-g" "install" "coffeescript"
npm ERR! node v0.12.0
npm ERR! npm  v2.5.1
npm ERR! code ELIFECYCLE

npm ERR! coffeescript@99.999.99999 preinstall: `node super-evil-script-omg-for-reals.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the coffeescript@99.999.99999 preinstall script 'node super-evil-script-omg-for-reals.js'.
npm ERR! This is most likely a problem with the coffeescript package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node super-evil-script-omg-for-reals.js
npm ERR! You can get their info via:
npm ERR!     npm owner ls coffeescript
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /home/fiws/Documents/myhubot/npm-debug.log
```
