### PR TITLE
Fix data.id check in GitterObject

### DIFF
--- a/src/GitterObject.coffee
+++ b/src/GitterObject.coffee
@@ -104,7 +104,7 @@ class GitterObject extends EventEmitter2
   # @param {Object} _data The core data of that gitter object
   # @option _data {String} id The id of that object
   constructor: (@_client, @_data) ->
-    throw new ReferenceError("no id given to create an object: #{ GitterObject.inspectArgs arguments }") unless _data?.id
+    throw new ReferenceError("no id given to create an object: #{ GitterObject.inspectArgs arguments }") unless @_data?.id
     # initialize our event emitter
     super {wildcard: yes, maxListeners: Infinity}
     @_promises = {}


### PR DESCRIPTION
New coffee parser (I tried 1.10.0) converts
`constructor: (@_client, @_data) ->` to `function GitterObject(_client, _data1)` and the `_data` check always fails because `_data` is renamed to `_data1`.

Thank you.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/huafu/hubot-gitter2/10)

<!-- Reviewable:end -->
