### PR TITLE
Inform users gitter2 needs a github account for hubot

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ yo hubot
 ```
 
 - save **hubot-gitter2** as dependency: `npm install --save hubot-gitter2`
-- start the bot using the right adapter: `HUBOT_GITTER2_TOKEN=<your token> ./bin/hubot -a gitter2 --name <your bot name>`
-    - `HUBOT_GITTER2_TOKEN`: get your personal token [there](http://developer.gitter.im) after sign-in
+- start the bot using the right adapter: `HUBOT_GITTER2_TOKEN=<your token> ./bin/hubot -a gitter2 --name <hubots github name>`
+    - `HUBOT_GITTER2_TOKEN`: use hubot's github account and obtain a personal token [here](http://developer.gitter.im) after sign-in
     - the bot will automatically listen on the rooms it has joined.
 
 ## Troubleshooting


### PR DESCRIPTION
It's not clear the hubot needs it's own github account from the documentation. I realized this after reading through old history in the gitter2's gitter room.
