### PR TITLE
require.main.require for hubot is not in packages.json

### DIFF
--- a/src/HubotGitter2Adapter.coffee
+++ b/src/HubotGitter2Adapter.coffee
@@ -1,4 +1,4 @@
-{Adapter,TextMessage} = require 'hubot'
+{Adapter,TextMessage} = require.main.require 'hubot'
 GitterObject          = require './GitterObject'
 GitterClient          = require './GitterClient'
 GitterUser            = require './GitterUser'


### PR DESCRIPTION
We could add hubot in devDependencies, but this `require.main.require` works when in production (stolen from hubot-slack plugin) and when hubot is not installed globally.
