### PR TITLE
integrate xyz for effortless releases

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-node_modules
-test.coffee

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Improved Hubot adapter for Gitter",
   "main": "src/gitter.coffee",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "release": "xyz --repo git@github.com:huafu/hubot-gitter2.git --increment",
+    "test": "echo 'No test specified'"
   },
   "repository": {
     "type": "git",
@@ -21,8 +22,17 @@
     "url": "https://github.com/huafu/hubot-gitter2/issues"
   },
   "homepage": "https://github.com/huafu/hubot-gitter2",
+  "files": [
+    "/src/",
+    "/LICENSE",
+    "/README.md",
+    "/package.json"
+  ],
   "dependencies": {
     "eventemitter2": "0.4.14",
     "node-gitter": "1.2.2"
+  },
+  "devDependencies": {
+    "xyz": "3.0.x"
   }
 }


### PR DESCRIPTION
See #18

This pull request adds [xyz][1] as a dev dependency to support the following commands:

```console
$ npm run release major
```

```console
$ npm run release minor
```

```console
$ npm run release patch
```

We can run one of the above with the `--dry-mode` option to see what it *would* do:

```console
$ npm run release -- minor --branch xyz --dry-run

> hubot-gitter2@0.1.3 release /Users/dc/github.com/huafu/hubot-gitter2
> xyz --repo git@github.com:huafu/hubot-gitter2.git --branch master --tag X.Y.Z --increment "minor" "--branch" "xyz" "--dry-run"

Current version is 0.1.3. Press [enter] to publish hubot-gitter2@0.2.0.
npm prune
npm test
node -e 'var o = require("./package.json"); o.version = "0.2.0"; require("fs").writeFileSync("./package.json", JSON.stringify(o, null, 2) + "\n");'
git add 'package.json'
git commit --message 'Version 0.2.0'
git tag --annotate '0.2.0' --message 'Version 0.2.0'
git push --atomic 'git@github.com:huafu/hubot-gitter2.git' 'refs/heads/xyz' 'refs/tags/0.2.0'
npm publish
```

Note that in the command above I specified `--branch xyz` because xyz will abort if one is on a different branch. In the actual command we specify `--branch master` as I assume we only ever want to publish from `master`.

These commands will work provided the following assumptions hold:

  - `xyz` is run from the specified branch;
  - the person running the command can push to this repository via SSH;
  - the person running the command can push this package to the public npm registry.

If you have any questions, @huafu, don't hesitate to ask. I'd love to see a new release soon so I can stop referencing a GitHub commit in my __package.json__. :)


[1]: https://github.com/davidchambers/xyz
